### PR TITLE
_mm_shuffle for area calculation

### DIFF
--- a/bvh.cpp
+++ b/bvh.cpp
@@ -241,11 +241,6 @@ void BVH::Subdivide( uint nodeIdx, uint depth, uint& nodePtr, float3& centroidMi
 	Subdivide( rightChildIdx, depth + 1, nodePtr, centroidMin, centroidMax );
 }
 
-#define MakeShuffleMask(x,y,z,w)     (x | (y<<2) | (z<<4) | (w<<6)) /* internal use only */
-// vec(0, 1, 2, 3) -> (vec[x], vec[y], vec[z], vec[w])
-#define VecSwizzleMask(vec, mask)    _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(vec), mask))
-#define VecSwizzle(vec, x, y, z, w)  VecSwizzleMask(vec, MakeShuffleMask(x,y,z,w))
-
 float BVH::FindBestSplitPlane( BVHNode& node, int& axis, int& splitPos, float3& centroidMin, float3& centroidMax )
 {
 	float bestCost = 1e30f;
@@ -292,10 +287,10 @@ float BVH::FindBestSplitPlane( BVHNode& node, int& axis, int& splitPos, float3& 
 			rightMax4 = _mm_max_ps( rightMax4, max4[BINS - 2 - i] );
 			__m128 le = _mm_sub_ps( leftMax4, leftMin4 );
 			__m128 re = _mm_sub_ps( rightMax4, rightMin4 );
-			le = _mm_and_ps( le, xyzMask4 );
-			re = _mm_and_ps( re, xyzMask4 );
-			leftCountArea[i] = leftSum * _mm_cvtss_f32( _mm_dp_ps( le, VecSwizzle( le, 1, 2, 0, 3 ), 0xff ) );
-			rightCountArea[BINS - 2 - i] = rightSum * _mm_cvtss_f32( _mm_dp_ps( re, VecSwizzle( re, 1, 2, 0, 3 ), 0xff ) );
+			
+			const int yzxShuffle = 9;
+			leftCountArea[i] = leftSum * _mm_cvtss_f32( _mm_dp_ps( le, _mm_shuffle_ps( le, le, yzxShuffle ), 0x7f ) );
+			rightCountArea[BINS - 2 - i] = rightSum * _mm_cvtss_f32( _mm_dp_ps( re, _mm_shuffle_ps( re, re, yzxShuffle ), 0x7f ) );
 		}
 #else
 		struct Bin { aabb bounds; int triCount = 0; } bin[BINS];
@@ -428,8 +423,8 @@ int TLAS::FindBestMatch( int N, int A )
 	{
 		__m128 bmax = _mm_max_ps( tlasNode[nodeIdx[A]].aabbMax4, tlasNode[nodeIdx[B]].aabbMax4 );
 		__m128 bmin = _mm_min_ps( tlasNode[nodeIdx[A]].aabbMin4, tlasNode[nodeIdx[B]].aabbMin4 );
-		__m128 e = _mm_and_ps( _mm_sub_ps( bmax, bmin ), xyzMask4 );
-		float surfaceArea = _mm_cvtss_f32( _mm_dp_ps( e, VecSwizzle( e, 1, 2, 0, 3 ), 0xff ) );
+		__m128 e = _mm_sub_ps( bmax, bmin );
+		float surfaceArea = _mm_cvtss_f32( _mm_dp_ps( e, _mm_shuffle_ps( e, e, 9 ), 0x7f ) );
 		if (surfaceArea < smallest) smallest = surfaceArea, bestB = B;
 	}
 	return bestB;


### PR DESCRIPTION
swizzling macro that was using integer instructions replaced by _mm_shuffle_ps
used 0x7f with _mm_dp_ps. removed _mm_and_ps accordingly.
TLAS construction is faster now (original was using float3)
BLAS construction is faster than before but tiny bit slower than first implementation. (almost same)